### PR TITLE
Bare Repository Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Additionally the `install-hooks` goal may be used to install a pre-commit Git ho
       <plugin>
         <groupId>io.committed</groupId>
         <artifactId>speedy-spotless-maven-plugin</artifactId>
-        <version>0.0.2</version>
+        <version>0.1.1</version>
         <executions>
           <execution>
             <id>install-formatter-hook</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.committed</groupId>
   <artifactId>speedy-spotless-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.1.0</version>
+  <version>0.1.1-SNAPSHOT</version>
   <name>speedy-spotless-maven-plugin</name>
   <description>For easy formatting of staged changes.</description>
   <url>http://github.com/commitd/speedy-spotless</url>
@@ -97,12 +97,17 @@
     <dependency>
       <groupId>com.diffplug.spotless</groupId>
       <artifactId>spotless-maven-plugin</artifactId>
-      <version>1.26.1</version>
+      <version>1.30.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.diffplug.spotless</groupId>
+      <artifactId>spotless-lib</artifactId>
+      <version>1.28.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>5.4.3.201909031940-r</version>
+      <version>5.7.0.202003110725-r</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.committed</groupId>
   <artifactId>speedy-spotless-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.1</version>
   <name>speedy-spotless-maven-plugin</name>
   <description>For easy formatting of staged changes.</description>
   <url>http://github.com/commitd/speedy-spotless</url>
@@ -71,7 +71,7 @@
       <plugin>
         <groupId>io.committed</groupId>
         <artifactId>speedy-spotless-maven-plugin</artifactId>
-        <version>0.0.2</version>
+        <version>0.1.1</version>
         <executions>
           <execution>
             <?m2e ignore?>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <plugin>
         <groupId>io.committed</groupId>
         <artifactId>speedy-spotless-maven-plugin</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.0</version>
         <executions>
           <execution>
             <?m2e ignore?>

--- a/test.sh
+++ b/test.sh
@@ -32,7 +32,7 @@ echo '<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w
       <plugin>
         <groupId>io.committed</groupId>
         <artifactId>speedy-spotless-maven-plugin</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.1.1</version>
         <configuration>
             <java>
               <googleJavaFormat>
@@ -53,7 +53,7 @@ git commit -m initial
 sed -i "" 's:\/\/ modline1:String s="";:g' "src/main/java/io/committed/speedy/Example.java"
 git add .
 
-mvn -X io.committed:speedy-spotless-maven-plugin:0.0.1-SNAPSHOT:staged
+mvn -X io.committed:speedy-spotless-maven-plugin:0.1.1:staged
 cat src/main/java/io/committed/speedy/Example.java
 cat pom.xml
 


### PR DESCRIPTION
Fixes issue where a "Bare Repository has neither a working tree, nor an index" message was thrown by JGit.

Also, updates JGit and Spotless to latest versions, and bumps version number for Speedy Spotless to 0.1.1.